### PR TITLE
Add HTML5 doctype declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,12 @@
 var React = require('react');
 var Router = require('react-router');
 
+var DefaultDocType = '<!doctype html>';
+
 function hapiReactRouter(server, options, done){
 
   var routes = options.routes;
+  options.doctype = options.doctype || DefaultDocType;
 
   server.decorate('reply', 'router', function(data){
     var response = this.response().hold();
@@ -13,7 +16,7 @@ function hapiReactRouter(server, options, done){
     Router.run(routes, this.request.url.path, function(Handler){
       var component = React.createElement(Handler, data);
       var html = React.renderToString(component);
-      response.source = html;
+      response.source = options.doctype + html;
       response.send();
     });
 


### PR DESCRIPTION
The lack of a doctype declaration can cause browsers to render in quirks mode. This adds a default HTML5 doctype and provides overriding via `options.doctype`.
